### PR TITLE
Add liblzfse dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "yourdfpy",
     "trimesh",
     "viser",
+    "pyliblzfse",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "yourdfpy",
     "trimesh",
     "viser",
-    "pyliblzfse",
+    "pyliblzfse",  # Need for viser.extras import in viser==0.2.23 
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Sweet work on this! I couldn't get the examples to run without additionally pip-installing pyliblzfse, though. Here's a quick patch

Great to see more robot infrastructure in Jax -- would love to chat sometime

P.S. If you are ever interested in robot dynamics in Jax, shameless plug for https://github.com/StanfordASL/oscbf/ :smiley: 

