### PR TITLE
Fix broadcasting logic in pairwise collision

### DIFF
--- a/src/pyroki/collision/_collision.py
+++ b/src/pyroki/collision/_collision.py
@@ -118,8 +118,8 @@ def pairwise_collide(geom1: CollGeom, geom2: CollGeom) -> Float[Array, "*batch N
     expected_output_shape = (*batch_combined_shape, N, M)
 
     result = jax.vmap(collide)(
-        geom1.broadcast_to(*expected_output_shape),
-        geom2.broadcast_to(*expected_output_shape),
+        geom1.reshape(*batch_combined_shape, N, 1).broadcast_to(*expected_output_shape),
+        geom2.reshape(*batch_combined_shape, 1, M).broadcast_to(*expected_output_shape),
     )
 
     assert result.shape == expected_output_shape, (


### PR DESCRIPTION
Previous broadcasting logic for `pairwise_collide` was incorrect (it was checking for collisions against _only_ itself, and not the other collision bodies in the potential pairs).

We now change it to:
```
     result = jax.vmap(collide)(
        geom1.reshape(*batch_combined_shape, N, 1).broadcast_to(*expected_output_shape),
        geom2.reshape(*batch_combined_shape, 1, M).broadcast_to(*expected_output_shape),
     )
```

Example of collision-aware bimanual IK working ([snippit](https://gist.github.com/chungmin99/775c3ce1a0c21caa76d80a166006cab7))


https://github.com/user-attachments/assets/f53dc123-95c1-41ba-92f4-c6916ac46989



(It's jerky because we're solving for a single IK position, not regularized by the previous timestep)