### PR TITLE
Feature/sdf obstacle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ htmlcov
 .envrc
 .vite
 build
+venv/

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ htmlcov
 .vite
 build
 venv/
+
+# Examples
+shadowhand_urdf/

--- a/examples/11_trajopt_sdf.py
+++ b/examples/11_trajopt_sdf.py
@@ -1,0 +1,203 @@
+"""Trajectory Optimization
+
+Basic Trajectory Optimization using PyRoKi.
+
+Robot going over a wall, while avoiding world-collisions.
+"""
+
+import time
+from typing import Literal
+
+import numpy as np
+import pyroki as pk
+import trimesh
+import tyro
+import viser
+from viser.extras import ViserUrdf
+from robot_descriptions.loaders.yourdfpy import load_robot_description
+
+import pyroki_snippets as pks
+
+
+def main(robot_name: Literal["ur5", "panda"] = "panda"):
+    if robot_name == "ur5":
+        urdf = load_robot_description("ur5_description")
+        down_wxyz = np.array([0.707, 0, 0.707, 0])
+        target_link_name = "ee_link"
+
+        # For UR5 it's important to initialize the robot in a safe configuration;
+        # the zero-configuration puts the robot aligned with the wall obstacle.
+        default_cfg = np.zeros(6)
+        default_cfg[1] = -1.308
+        robot = pk.Robot.from_urdf(urdf, default_joint_cfg=default_cfg)
+
+    elif robot_name == "panda":
+        urdf = load_robot_description("panda_description")
+        target_link_name = "panda_hand"
+        down_wxyz = np.array([0, 0, 1, 0])  # for panda!
+        robot = pk.Robot.from_urdf(urdf)
+
+    else:
+        raise ValueError(f"Invalid robot: {robot_name}")
+
+    robot_coll = pk.collision.RobotCollision.from_urdf(urdf)
+
+    # Define the trajectory problem:
+    # - number of timesteps, timestep size
+    timesteps, dt = 25, 0.02
+    # - the start and end poses.
+    start_pos, end_pos = np.array([0.5, -0.3, 0.2]), np.array([0.5, 0.3, 0.2])
+
+    # Define the obstacles:
+    # - Ground
+    ground_coll = pk.collision.HalfSpace.from_point_and_normal(
+        np.array([0.0, 0.0, 0.0]), np.array([0.0, 0.0, 1.0])
+    )
+    # - Wall
+    wall_height = 0.4
+    wall_width = 0.1
+    wall_length = 0.4
+    wall_intervals = np.arange(start=0.3, stop=wall_length + 0.3, step=0.05)
+    translation = np.concatenate(
+        [
+            wall_intervals.reshape(-1, 1),
+            np.full((wall_intervals.shape[0], 1), 0.0),
+            np.full((wall_intervals.shape[0], 1), wall_height / 2),
+        ],
+        axis=1,
+    )
+    # wall_coll = pk.collision.Capsule.from_radius_height(
+    #     position=translation,
+    #     radius=np.full((translation.shape[0], 1), wall_width / 2),
+    #     height=np.full((translation.shape[0], 1), wall_height),
+    # )
+    # world_coll = [ground_coll, wall_coll]
+
+    import jax.numpy as jnp
+    import jax
+    import trimesh                     # only for quick visual check (optional)
+    import jaxlie
+
+    # ---------------------------------------------------------------------
+    # Helper: make a voxel grid centred at `origin` with resolution `voxel`
+    # ---------------------------------------------------------------------
+    def make_grid(origin_xyz, voxel, dims_xyz):
+        """
+        origin_xyz : (3,)  world-frame coordinates of grid corner (x0,y0,z0)
+        voxel      : (3,)  voxel sizes (dx,dy,dz)
+        dims_xyz   : (3,)  integer number of cells in x,y,z
+        """
+        nx, ny, nz = dims_xyz
+        dx, dy, dz = voxel
+        # coordinate centres of every voxel in world frame
+        xs = origin_xyz[0] + (jnp.arange(nx) + 0.5) * dx
+        ys = origin_xyz[1] + (jnp.arange(ny) + 0.5) * dy
+        zs = origin_xyz[2] + (jnp.arange(nz) + 0.5) * dz
+        # shape (nz,ny,nx,3) –– we keep z-major so marching-cubes later is easier
+        grid_pts = jnp.stack(jnp.meshgrid(xs, ys, zs, indexing="xy"), axis=-1)
+        grid_pts = jnp.moveaxis(grid_pts, 2, 0)              # (z,y,x,3)
+        return grid_pts
+
+
+    # ---------------------------------------------------------------------
+    # Primitives: sphere SDF and axis-aligned box SDF
+    # ---------------------------------------------------------------------
+    def sdf_sphere(pts, centre, radius):
+        """Signed distance to a sphere."""
+        return jnp.linalg.norm(pts - centre, axis=-1) - radius
+
+    def sdf_box(pts, centre, half_extents):
+        """Axis-aligned box; positive outside, negative inside."""
+        q = jnp.abs(pts - centre) - half_extents
+        outside = jnp.linalg.norm(jnp.clip(q, 0), axis=-1)
+        inside  = jnp.max(jnp.minimum(q, 0), axis=-1)
+        return outside + inside
+
+
+    # ---------------------------------------------------------------------
+    # Build a 64³ grid with two obstacles
+    # ---------------------------------------------------------------------
+    voxel       = jnp.array([0.02, 0.02, 0.02])          # 2 cm voxels
+    dims_xyz    = (64, 64, 64)
+    origin_xyz  = jnp.array([-0.64, -0.64, -0.02])       # put z=0 roughly in the middle
+
+    grid_pts = make_grid(origin_xyz, voxel, dims_xyz)    # (64,64,64,3)
+    sphere_sdf = sdf_sphere(grid_pts,
+                            centre=jnp.array([0.0, 0.0, 0.25]),
+                            radius=0.50)
+
+    box_sdf    = sdf_box(grid_pts,
+                        centre=jnp.array([0.3, 0.0, 0.10]),
+                        half_extents=jnp.array([0.08, 0.30, 0.10]))
+
+    # *union* (can also take min() for intersection, -min(-d) for union of negatives, etc.)
+    combined_sdf = jnp.minimum(sphere_sdf, box_sdf)      # (z,y,x)
+    combined_sdf = jnp.minimum(sphere_sdf)
+
+    # ---------------------------------------------------------------------
+    # Wrap it in an SDFGrid CollGeom (see previous answer §1)
+    # ---------------------------------------------------------------------
+
+    grid = pk.collision.SDFGrid(
+        pose        = jaxlie.SE3.identity(),             # grid frame ≡ world for now
+        size        = voxel,                             # optional; not used for distance
+        sdf         = combined_sdf,                      # (Z,Y,X)
+        voxel_size  = voxel,
+    )
+
+    # Now `grid_geom` can be appended to your `world_coll` list:
+    # world_coll = [ground_coll, grid_geom]
+    world_coll = [ground_coll, grid]    # ← feed into solve_trajopt exactly like before
+
+
+    traj = pks.solve_trajopt(
+        robot,
+        robot_coll,
+        world_coll,
+        target_link_name,
+        start_pos,
+        down_wxyz,
+        end_pos,
+        down_wxyz,
+        timesteps,
+        dt,
+    )
+    traj = np.array(traj)
+
+    # Visualize!
+    server = viser.ViserServer()
+    urdf_vis = ViserUrdf(server, urdf)
+    server.scene.add_grid("/grid", width=2, height=2, cell_size=0.1)
+    server.scene.add_mesh_trimesh(
+        "wall_box",
+        trimesh.creation.box(
+            extents=(wall_length, wall_width, wall_height),
+            transform=trimesh.transformations.translation_matrix(
+                np.array([0.5, 0.0, wall_height / 2])
+            ),
+        ),
+    )
+    for name, pos in zip(["start", "end"], [start_pos, end_pos]):
+        server.scene.add_frame(
+            f"/{name}",
+            position=pos,
+            wxyz=down_wxyz,
+            axes_length=0.05,
+            axes_radius=0.01,
+        )
+
+    slider = server.gui.add_slider(
+        "Timestep", min=0, max=timesteps - 1, step=1, initial_value=0
+    )
+    playing = server.gui.add_checkbox("Playing", initial_value=True)
+
+    while True:
+        if playing.value:
+            slider.value = (slider.value + 1) % timesteps
+
+        urdf_vis.update_cfg(traj[slider.value])
+        time.sleep(1.0 / 10.0)
+
+
+if __name__ == "__main__":
+    tyro.cli(main)

--- a/examples/11_trajopt_sdf.py
+++ b/examples/11_trajopt_sdf.py
@@ -11,6 +11,7 @@ from typing import Literal
 import numpy as np
 import pyroki as pk
 import trimesh
+from trimesh.voxel import ops as voxel_ops          # marching-cubes helper
 import tyro
 import viser
 from viser.extras import ViserUrdf
@@ -18,6 +19,91 @@ from robot_descriptions.loaders.yourdfpy import load_robot_description
 
 import pyroki_snippets as pks
 
+import jax.numpy as jnp
+import jaxlie
+
+def make_sphere_grid(world_center: jnp.ndarray,
+                     radius: float,
+                     voxel: tuple[float, float, float] = (0.02, 0.02, 0.02),
+                     dims: tuple[int, int, int] = (64, 64, 64),
+) -> pk.collision.SDFGrid:
+    """
+    Build a corner-anchored cubic SDF grid containing a single sphere.
+
+    Parameters
+    ----------
+    world_center : (3,) world-frame xyz of the sphere centre.
+    radius       : sphere radius [m].
+    voxel        : (dx, dy, dz) voxel size [m].
+    dims         : (nx, ny, nz) number of cells.
+
+    Returns
+    -------
+    SDFGrid  ready to append to `world_coll`.
+    """
+    voxel = jnp.asarray(voxel)
+    nx, ny, nz = dims
+    # local voxel centres (corner-anchored)
+    xs = jnp.arange(nx) * voxel[0]
+    ys = jnp.arange(ny) * voxel[1]
+    zs = jnp.arange(nz) * voxel[2]
+    pts = jnp.stack(jnp.meshgrid(xs, ys, zs, indexing="xy"), axis=-1)
+    pts = jnp.moveaxis(pts, 2, 0)                     # (z,y,x,3)
+
+    idx_half = (jnp.asarray(dims) - 1) / 2            # 31.5,31.5,31.5
+    local_center = idx_half * voxel                   # metres in grid frame
+
+    sdf = jnp.linalg.norm(pts - local_center, axis=-1) - radius
+
+    grid_origin_w = world_center - local_center       # place array corner
+    pose = jaxlie.SE3.from_translation(grid_origin_w)
+
+    return pk.collision.SDFGrid(
+        pose       = pose,
+        voxel_size = voxel,
+        size       = voxel,   # not used in distance but kept for completeness
+        sdf        = sdf,
+    )
+
+
+def add_sdf_to_viser(server: viser.ViserServer,
+                     name: str,
+                     grid: pk.collision.SDFGrid,
+                     level: float = 0.0,
+                     rgba=(0, 255, 0, 120)):
+    """
+    Extract the iso-surface `grid.sdf == level` and add it to Viser.
+
+    Parameters
+    ----------
+    server : viser.ViserServer
+    name   : path under which to insert the mesh (e.g. "/sdf_mesh")
+    grid   : pk.collision.SDFGrid
+    level  : iso-value (0.0 for the surface)
+    rgba   : mesh colour & alpha
+    """
+    # --- 1  marching cubes in *grid* frame --------------------------
+    sdf_np = np.asarray(grid.sdf)                 # (Z, Y, X)
+    # trimesh.voxel expects X,Y,Z ordering
+    sdf_np = sdf_np.transpose(2, 1, 0)            # → (X, Y, Z)
+
+    verts, faces = voxel_ops.matrix_to_marching_cubes(
+        sdf_np, pitch=float(grid.voxel_size[0]), level=level)
+
+    # if voxels are anisotropic, rescale vertices
+    verts *= np.asarray(grid.voxel_size[::-1])    # X,Y,Z order
+
+    mesh = trimesh.Trimesh(verts, faces, process=False)
+
+    # --- 2  move from grid-local to world frame --------------------
+    mesh.apply_transform(grid.pose.as_matrix())   # 4×4 world←grid
+
+    # --- 3  send to Viser -----------------------------------------
+    server.scene.add_mesh_trimesh(
+        name=name,
+        mesh=mesh,
+        rgba=rgba,
+    )
 
 def main(robot_name: Literal["ur5", "panda"] = "panda"):
     if robot_name == "ur5":
@@ -66,134 +152,10 @@ def main(robot_name: Literal["ur5", "panda"] = "panda"):
         ],
         axis=1,
     )
-    # wall_coll = pk.collision.Capsule.from_radius_height(
-    #     position=translation,
-    #     radius=np.full((translation.shape[0], 1), wall_width / 2),
-    #     height=np.full((translation.shape[0], 1), wall_height),
-    # )
-    # world_coll = [ground_coll, wall_coll]
 
-    import jax.numpy as jnp
-    import jax
-    import trimesh                     # only for quick visual check (optional)
-    import jaxlie
-
-    # ---------------------------------------------------------------------
-    # Helper: make a voxel grid centred at `origin` with resolution `voxel`
-    # ---------------------------------------------------------------------
-    def make_grid(voxel, dims_xyz):
-        nx, ny, nz = dims_xyz
-        dx, dy, dz = voxel
-        xs = (jnp.arange(nx) - (nx - 1) / 2) * dx
-        ys = (jnp.arange(ny) - (ny - 1) / 2) * dy
-        zs = (jnp.arange(nz) - (nz - 1) / 2) * dz
-        grid_pts = jnp.stack(jnp.meshgrid(xs, ys, zs, indexing="xy"), axis=-1)
-        grid_pts = jnp.moveaxis(grid_pts, 2, 0)     # (z,y,x,3)
-        return grid_pts
-
-
-    # ---------------------------------------------------------------------
-    # Primitives: sphere SDF and axis-aligned box SDF
-    # ---------------------------------------------------------------------
-    def sdf_sphere(pts, centre, radius):
-        """Signed distance to a sphere."""
-        return jnp.linalg.norm(pts - centre, axis=-1) - radius
-
-    def sdf_box(pts, centre, half_extents):
-        """Axis-aligned box; positive outside, negative inside."""
-        q = jnp.abs(pts - centre) - half_extents
-        outside = jnp.linalg.norm(jnp.clip(q, 0), axis=-1)
-        inside  = jnp.max(jnp.minimum(q, 0), axis=-1)
-        return outside + inside
-
-
-    # ---------------------------------------------------------------------
-    # Build a 64³ grid with two obstacles
-    # ---------------------------------------------------------------------
-    voxel = jnp.array([0.02, 0.02, 0.02])
-    dims_xyz = (64, 64, 64)
-    idx_half = (jnp.array(dims_xyz) - 1) / 2.0            # (31.5, 31.5, 31.5)
-    sphere_w = jnp.array([0.5, 0.0, 0.18])                 # where you want the centre
-
-    # 1. Build a *corner-anchored* grid (origin at (0,0,0) local)
-    def make_grid_corner(voxel, dims_xyz):
-        nx, ny, nz = dims_xyz
-        dx, dy, dz = voxel
-        xs = jnp.arange(nx) * dx
-        ys = jnp.arange(ny) * dy
-        zs = jnp.arange(nz) * dz
-        pts = jnp.stack(jnp.meshgrid(xs, ys, zs, indexing="xy"), axis=-1)
-        pts = jnp.moveaxis(pts, 2, 0)           # (z,y,x,3)
-        return pts
-
-    grid_pts = make_grid_corner(voxel, dims_xyz)
-
-    # 2. Build sphere SDF in *local* coordinates
-    sphere_sdf = sdf_sphere(grid_pts,
-                            centre=idx_half * voxel,   #  centre at array middle
-                            radius=0.2)
-
-    # 3. Place the grid so that index (0,0,0) sits at world = sphere_w − idx_half*voxel
-    grid_origin_w = sphere_w - idx_half * voxel
-
-    grid = pk.collision.SDFGrid(
-        pose       = jaxlie.SE3.from_translation(grid_origin_w),   # CORNER
-        voxel_size = voxel,
-        size       = voxel,
-        sdf        = sphere_sdf,
-    )
-
-
-    box_sdf    = sdf_box(grid_pts,
-                        centre=jnp.array([0.3, 0.0, 0.10]),
-                        half_extents=jnp.array([0.08, 0.30, 0.10]))
-
-    # *union* (can also take min() for intersection, -min(-d) for union of negatives, etc.)
-    combined_sdf = jnp.minimum(sphere_sdf, box_sdf)      # (z,y,x)
-    combined_sdf = sphere_sdf
-
-    # ---------------------------------------------------------------------
-    # Wrap it in an SDFGrid CollGeom (see previous answer §1)
-    # ---------------------------------------------------------------------
-
-    # grid = pk.collision.SDFGrid(
-    #     pose = jaxlie.SE3.from_translation(jnp.array([0.7, 0.0, 0.0])),  # centre of sphere
-    #     size = voxel,
-    #     voxel_size = voxel,
-    #     sdf  = combined_sdf,
-    # )
-
-    # Now `grid_geom` can be appended to your `world_coll` list:
-    # world_coll = [ground_coll, grid_geom]
-    world_coll = [ground_coll, grid]    # ← feed into solve_trajopt exactly like before
-
-    import jax.numpy as jnp
-    from functools import partial
-
-    # -------------------------------------------------------
-    # 1. zero-level sanity check
-    # -------------------------------------------------------
-    sphere_center_w = jnp.array([0.7, 0.0, 0.2])          # same as you used
-    # single-point query – robust to any  leading broadcast axes
-    sdf_at_center = grid._interpolate_sdf(sphere_center_w).reshape(()).item()
-    print(f"SDF(center) = {sdf_at_center:+.4f} m")
-
-    print(f"SDF(center)   = {sdf_at_center:+.4f} m "
-        "(should be ~0: inside the grid & oriented right)")
-    
-    sdf_at_center = grid._interpolate_sdf(sphere_w).reshape(()).item()
-    print(f"SDF(center) = {sdf_at_center:+.4f}  (≈ -0.30 expected)")
-
-    # -------------------------------------------------------
-    # 2. grid pose & extent sanity check
-    # -------------------------------------------------------
-    grid_min_w = grid.pose.apply(jnp.array([0, 0, 0]))                 # corner
-    grid_max_w = grid.pose.apply(
-        (jnp.array(grid.sdf.shape[::-1]) - 1) * grid.voxel_size)       # opposite corner
-    print(f"Grid spans X:[{grid_min_w[0]:+.2f},{grid_max_w[0]:+.2f}] m "
-        f"Y:[{grid_min_w[1]:+.2f},{grid_max_w[1]:+.2f}] m "
-        f"Z:[{grid_min_w[2]:+.2f},{grid_max_w[2]:+.2f}] m")
-
+    grid = make_sphere_grid(world_center=jnp.array([0.5, 0.0, 0.18]),
+                        radius=0.20)
+    world_coll = [ground_coll, grid]
 
     traj = pks.solve_trajopt(
         robot,
@@ -208,22 +170,6 @@ def main(robot_name: Literal["ur5", "panda"] = "panda"):
         dt,
     )
     traj = np.array(traj)
-
-    import jax.numpy as jnp
-    from functools import partial
-
-    # # Wrap once so we JIT only a single function call, not 25×
-    # @partial(jax.jit, static_argnums=(0, 1))
-    def min_signed_distance(robot, robot_coll, cfg, world_geom):
-        dist = robot_coll.compute_world_collision_distance(robot, cfg, world_geom)
-        return jnp.min(dist)          # single scalar: most negative penetration
-
-    for t, q in enumerate(traj):
-        d = float(min_signed_distance(robot, robot_coll,
-                                    jnp.asarray(q),   # cfg shape (DoF,)
-                                    grid))            # or world_coll[1]
-        print(f"step {t:02d}  min-dist = {d:+.4f} m")
-
 
     # Visualize!
     server = viser.ViserServer()
@@ -252,35 +198,7 @@ def main(robot_name: Literal["ur5", "panda"] = "panda"):
     )
     playing = server.gui.add_checkbox("Playing", initial_value=True)
 
-    # # ---- SDF  → trimesh  --------------------------------------------------
-    # # import numpy as np
-    # # import trimesh
-    # from trimesh.voxel import ops as voxel_ops     # uses skimage’s marching-cubes
-
-    # # jax → numpy
-    # sdf_np   = jnp.asarray(combined_sdf)         # (Z, Y, X)
-    # inside   = sdf_np <= 0.0                    # boolean occupancy
-
-    # # trimesh expects (X, Y, Z) ordering
-    # mc_mesh = voxel_ops.matrix_to_marching_cubes(
-    #     inside.transpose(2, 1, 0),              # → (X,Y,Z)
-    #     pitch=float(voxel[0])                   # or tuple(voxel) if anisotropic
-    # )
-
-    # # move mesh from grid-local coordinates into world coordinates
-    # # 1. Evaluate the property           ↓ parentheses!
-    # world_offset = np.asarray(origin_local) + np.asarray(grid.pose.translation())
-
-    # mc_mesh.apply_translation(world_offset)
-
-
-    # # ---- drop into viser --------------------------------------------------
-    # server.scene.add_mesh_trimesh(
-    #     name="/sdf_mesh",
-    #     mesh=mc_mesh,
-    #     wxyz=(1.0, 0.0, 0.0, 0.0),              # no rotation
-    #     visible=True,
-    # )
+    add_sdf_to_viser(server, "/sdf_mesh", grid)
 
 
     while True:

--- a/examples/11_trajopt_sdf.py
+++ b/examples/11_trajopt_sdf.py
@@ -127,19 +127,6 @@ def main(robot_name: Literal["ur5", "panda"] = "panda"):
     ground_coll = pk.collision.HalfSpace.from_point_and_normal(
         np.array([0.0, 0.0, 0.0]), np.array([0.0, 0.0, 1.0])
     )
-    # - Wall
-    wall_height = 0.4
-    wall_width = 0.1
-    wall_length = 0.4
-    wall_intervals = np.arange(start=0.3, stop=wall_length + 0.3, step=0.05)
-    translation = np.concatenate(
-        [
-            wall_intervals.reshape(-1, 1),
-            np.full((wall_intervals.shape[0], 1), 0.0),
-            np.full((wall_intervals.shape[0], 1), wall_height / 2),
-        ],
-        axis=1,
-    )
 
     grid = make_sphere_grid(world_center=jnp.array([0.5, 0.0, 0.18]),
                         radius=0.20)
@@ -163,15 +150,6 @@ def main(robot_name: Literal["ur5", "panda"] = "panda"):
     server = viser.ViserServer()
     urdf_vis = ViserUrdf(server, urdf)
     server.scene.add_grid("/grid", width=2, height=2, cell_size=0.1)
-    server.scene.add_mesh_trimesh(
-        "wall_box",
-        trimesh.creation.box(
-            extents=(wall_length, wall_width, wall_height),
-            transform=trimesh.transformations.translation_matrix(
-                np.array([0.5, 0.0, wall_height / 2])
-            ),
-        ),
-    )
     for name, pos in zip(["start", "end"], [start_pos, end_pos]):
         server.scene.add_frame(
             f"/{name}",

--- a/examples/12_online_planning_sdf.py
+++ b/examples/12_online_planning_sdf.py
@@ -1,0 +1,188 @@
+"""Online Planning
+
+Run online planning in collision aware environments.
+"""
+
+import time
+
+import numpy as np
+import jax.numpy as jnp
+import jaxlie
+import pyroki as pk
+import viser
+from pyroki.collision import HalfSpace, RobotCollision, Sphere
+from robot_descriptions.loaders.yourdfpy import load_robot_description
+from viser.extras import ViserUrdf
+import trimesh
+from trimesh.voxel import ops as voxel_ops          # marching-cubes helper
+
+import pyroki_snippets as pks
+
+def make_sphere_grid(world_center: jnp.ndarray,
+                     radius: float,
+                     voxel: tuple[float, float, float] = (0.02, 0.02, 0.02),
+                     dims: tuple[int, int, int] = (64, 64, 64),
+) -> pk.collision.SDFGrid:
+    """
+    Build a corner-anchored cubic SDF grid containing a single sphere.
+
+    Parameters
+    ----------
+    world_center : (3,) world-frame xyz of the sphere centre.
+    radius       : sphere radius [m].
+    voxel        : (dx, dy, dz) voxel size [m].
+    dims         : (nx, ny, nz) number of cells.
+
+    Returns
+    -------
+    SDFGrid  ready to append to `world_coll`.
+    """
+    voxel = jnp.asarray(voxel)
+    nx, ny, nz = dims
+    # local voxel centres (corner-anchored)
+    xs = jnp.arange(nx) * voxel[0]
+    ys = jnp.arange(ny) * voxel[1]
+    zs = jnp.arange(nz) * voxel[2]
+    pts = jnp.stack(jnp.meshgrid(xs, ys, zs, indexing="xy"), axis=-1)
+    pts = jnp.moveaxis(pts, 2, 0)                     # (z,y,x,3)
+
+    idx_half = (jnp.asarray(dims) - 1) / 2            # 31.5,31.5,31.5
+    local_center = idx_half * voxel                   # metres in grid frame
+
+    sdf = jnp.linalg.norm(pts - local_center, axis=-1) - radius
+
+    grid_origin_w = world_center - local_center       # place array corner
+    pose = jaxlie.SE3.from_translation(grid_origin_w)
+
+    return pk.collision.SDFGrid(
+        pose       = pose,
+        voxel_size = voxel,
+        size       = voxel,   # not used in distance but kept for completeness
+        sdf        = sdf,
+    )
+
+
+def add_sdf_to_viser(server, name, grid, level=0.0):
+    # ------------ 1. extract mesh in grid frame --------------------
+    sdf_np = np.array(grid.sdf, dtype=np.float32)        # make *writable*
+    sdf_np = sdf_np.transpose(2, 1, 0)                   # (X,Y,Z) for both libs
+
+    verts, faces = None, None
+    try:
+        # prefer skimage if available
+        from skimage.measure import marching_cubes
+        verts, faces, _, _ = marching_cubes(
+            sdf_np, level=level, spacing=tuple(grid.voxel_size[::-1]))
+    except Exception:
+        # occupancy fallback (dx must equal dy == dz)
+        inside = sdf_np <= level
+        verts, faces = voxel_ops.matrix_to_marching_cubes(
+            inside, pitch=float(grid.voxel_size[0]))
+        verts *= np.asarray(grid.voxel_size[::-1])        # rescale anisotropic
+
+    mesh = trimesh.Trimesh(verts, faces, process=False)
+
+    # ------------ 2. move to world frame --------------------------
+    mesh.apply_transform(grid.pose.as_matrix())
+
+    # ------------ 3. send to Viser -------------------------------
+    server.scene.add_mesh_trimesh(name=name, mesh=mesh)
+
+def main():
+    """Main function for online planning with collision."""
+    urdf = load_robot_description("panda_description")
+    target_link_name = "panda_hand"
+    robot = pk.Robot.from_urdf(urdf)
+
+    robot_coll = RobotCollision.from_urdf(urdf)
+    plane_coll = HalfSpace.from_point_and_normal(
+        np.array([0.0, 0.0, 0.0]), np.array([0.0, 0.0, 1.0])
+    )
+    sphere_coll = Sphere.from_center_and_radius(
+        np.array([0.0, 0.0, 0.0]), np.array([0.05])
+    )
+
+    # Define the online planning parameters.
+    len_traj, dt = 5, 0.1
+
+    # Set up visualizer.
+    server = viser.ViserServer()
+    server.scene.add_grid("/ground", width=2, height=2, cell_size=0.1)
+    urdf_vis = ViserUrdf(server, urdf, root_node_name="/robot")
+
+    # Create interactive controller for IK target.
+    ik_target_handle = server.scene.add_transform_controls(
+        "/ik_target", scale=0.2, position=(0.3, 0.0, 0.5), wxyz=(0, 0, 1, 0)
+    )
+
+    # Create interactive controller and mesh for the sphere obstacle.
+    sphere_handle = server.scene.add_transform_controls(
+        "/obstacle", scale=0.2, position=(0.4, 0.3, 0.4)
+    )
+    server.scene.add_mesh_trimesh("/obstacle/mesh", mesh=sphere_coll.to_trimesh())
+    target_frame_handle = server.scene.add_batched_axes(
+        "target_frame",
+        axes_length=0.05,
+        axes_radius=0.005,
+        batched_positions=np.zeros((25, 3)),
+        batched_wxyzs=np.array([[1.0, 0.0, 0.0, 0.0]] * 25),
+    )
+
+    timing_handle = server.gui.add_number("Elapsed (ms)", 0.001, disabled=True)
+
+    sol_pos, sol_wxyz = None, None
+    sol_traj = np.array(
+        robot.joint_var_cls.default_factory()[None].repeat(len_traj, axis=0)
+    )
+
+
+
+    grid = make_sphere_grid(world_center=jnp.array([0.5, 0.0, 0.18]),
+                        radius=0.20)
+
+    add_sdf_to_viser(server, "/sdf_mesh", grid)
+
+    while True:
+        start_time = time.time()
+
+        sphere_coll_world_current = sphere_coll.transform_from_wxyz_position(
+            wxyz=np.array(sphere_handle.wxyz),
+            position=np.array(sphere_handle.position),
+        )
+
+        world_coll_list = [plane_coll, sphere_coll_world_current, grid]
+        sol_traj, sol_pos, sol_wxyz = pks.solve_online_planning(
+            robot=robot,
+            robot_coll=robot_coll,
+            world_coll=world_coll_list,
+            target_link_name=target_link_name,
+            target_position=np.array(ik_target_handle.position),
+            target_wxyz=np.array(ik_target_handle.wxyz),
+            timesteps=len_traj,
+            dt=dt,
+            start_cfg=sol_traj[0],
+            prev_sols=sol_traj,
+        )
+
+        # Update timing handle.
+        timing_handle.value = (
+            0.99 * timing_handle.value + 0.01 * (time.time() - start_time) * 1000
+        )
+
+        # Update visualizer.
+        urdf_vis.update_cfg(
+            sol_traj[0]
+        )  # The first step of the online trajectory solution.
+
+        # Update the planned trajectory visualization.
+        if hasattr(target_frame_handle, "batched_positions"):
+            target_frame_handle.batched_positions = np.array(sol_pos)  # type: ignore[attr-defined]
+            target_frame_handle.batched_wxyzs = np.array(sol_wxyz)  # type: ignore[attr-defined]
+        else:
+            # This is an older version of Viser.
+            target_frame_handle.positions_batched = np.array(sol_pos)  # type: ignore[attr-defined]
+            target_frame_handle.wxyzs_batched = np.array(sol_wxyz)  # type: ignore[attr-defined]
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pyroki/collision/__init__.py
+++ b/src/pyroki/collision/__init__.py
@@ -7,4 +7,5 @@ from ._geometry import CollGeom as CollGeom
 from ._geometry import HalfSpace as HalfSpace
 from ._geometry import Heightmap as Heightmap
 from ._geometry import Sphere as Sphere
+from ._geometry import SDFGrid as SDFGrid
 from ._robot_collision import RobotCollision as RobotCollision

--- a/src/pyroki/collision/_collision.py
+++ b/src/pyroki/collision/_collision.py
@@ -6,7 +6,7 @@ import jax
 import jax.numpy as jnp
 from jaxtyping import Array, Float
 
-from ._geometry import Capsule, CollGeom, HalfSpace, Heightmap, Sphere
+from ._geometry import Capsule, CollGeom, HalfSpace, Heightmap, Sphere, SDFGrid
 from ._geometry_pairs import (
     capsule_capsule,
     halfspace_capsule,
@@ -16,6 +16,8 @@ from ._geometry_pairs import (
     heightmap_sphere,
     sphere_capsule,
     sphere_sphere,
+    sdfgrid_capsule,
+    sdfgrid_sphere
 )
 
 COLLISION_FUNCTIONS: Dict[
@@ -29,6 +31,8 @@ COLLISION_FUNCTIONS: Dict[
     (Heightmap, Sphere): heightmap_sphere,
     (Heightmap, Capsule): heightmap_capsule,
     (Heightmap, HalfSpace): heightmap_halfspace,
+    (SDFGrid, Sphere): sdfgrid_sphere,
+    (SDFGrid, Capsule): sdfgrid_capsule,
 }
 
 

--- a/src/pyroki/collision/_geometry_pairs.py
+++ b/src/pyroki/collision/_geometry_pairs.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import jax.numpy as jnp
 from jaxtyping import Float, Array
 
-from ._geometry import HalfSpace, Sphere, Capsule, Heightmap
+from ._geometry import HalfSpace, Sphere, Capsule, Heightmap, SDFGrid
 from . import _utils
 
 
@@ -216,3 +216,16 @@ def heightmap_halfspace(
     min_dist = jnp.min(vertex_distances, axis=-1)
     assert min_dist.shape == batch_axes
     return min_dist
+
+def sdfgrid_sphere(grid: SDFGrid, sph: Sphere) -> Float[Array, "*batch"]:
+    # signed distance at the centre minus radius
+    d = grid._interpolate_sdf(sph.pose.translation()) - sph.radius
+    return d
+
+def sdfgrid_capsule(grid: SDFGrid, cap: Capsule,
+                    n=5) -> Float[Array, "*batch"]:
+    # sample N points along the capsule axis, take min(dist - radius)
+    seg = jnp.linspace(-0.5, 0.5, n)[..., None] * cap.height[..., None]
+    pts_c = cap.axis[..., None, :] * seg + cap.pose.translation()[..., None, :]
+    d = grid._interpolate_sdf(pts_c) - cap.radius[..., None]
+    return jnp.min(d, axis=-1)


### PR DESCRIPTION
- Add signed distance field (SDF) collision geometry `CollGeom` to allow users to specify arbitrary SDF as obstacles
- Add versions of examples `07_trajopt` and `06_online_planning` using simple SDF as `11_trajopt_sdf` and `12_online_planning_sdf`, respectively.
- ^ Above also included helper functions to define spherical SDF, as well as to visualize the 0-level set of the SDF
- Minor tweaks to the gitignore (ignore `venv/` and `shawdowhand_urdf`)