### PR TITLE
Support joint locking through masking Jacobian calculations

### DIFF
--- a/examples/13_ik_with_locked_joints.py
+++ b/examples/13_ik_with_locked_joints.py
@@ -1,10 +1,8 @@
 """IK with Locked Joints
 
-Demonstrates and benchmarks two joint locking approaches during IK optimization:
-1. Masked Jacobian: Zeros out Jacobian columns for locked joints (approach in _solve_ik_masked)
-2. Masked Retraction: Uses custom retract_fn to filter delta updates (approach in _solve_ik_retract_masked)
-
-Uses checkboxes to dynamically lock/unlock individual joints without triggering JAX recompilation.
+Demonstrates joint locking during IK optimization by zeroing out Jacobian columns
+for locked joints. Uses checkboxes to dynamically lock/unlock individual joints
+without triggering JAX recompilation.
 """
 
 import time
@@ -19,6 +17,89 @@ import pyroki as pk
 import viser
 from robot_descriptions.loaders.yourdfpy import load_robot_description
 from viser.extras import ViserUrdf
+
+
+@jdc.jit
+def _solve_ik(
+    robot: pk.Robot,
+    target_link_index: jax.Array,
+    target_wxyz: jax.Array,
+    target_position: jax.Array,
+    joint_mask: jax.Array,
+    prev_cfg: jax.Array,
+) -> jax.Array:
+    """Solve IK with masked (locked) joints.
+
+    Args:
+        robot: Robot model.
+        target_link_index: Index of the target link.
+        target_wxyz: Target orientation quaternion (w, x, y, z).
+        target_position: Target position (x, y, z).
+        joint_mask: Array of shape (n_actuated,). 1.0 = optimize, 0.0 = lock.
+        prev_cfg: Previous joint configuration (used as initial guess).
+
+    Returns:
+        Optimized joint configuration.
+    """
+    joint_var = robot.joint_var_cls(0)
+
+    target_pose = jaxlie.SE3.from_rotation_and_translation(
+        jaxlie.SO3(target_wxyz), target_position
+    )
+
+    costs = [
+        pk.costs.pose_cost_analytic_jac(
+            robot,
+            joint_var,
+            target_pose,
+            target_link_index,
+            pos_weight=50.0,
+            ori_weight=10.0,
+            joint_mask=joint_mask,
+        ),
+        pk.costs.limit_constraint(
+            robot,
+            joint_var,
+        ),
+    ]
+
+    sol = (
+        jaxls.LeastSquaresProblem(costs=costs, variables=[joint_var])
+        .analyze()
+        .solve(
+            verbose=False,
+            linear_solver="dense_cholesky",
+            trust_region=jaxls.TrustRegionConfig(lambda_initial=1.0),
+            initial_vals=jaxls.VarValues.make([joint_var.with_value(prev_cfg)]),
+        )
+    )
+    return sol[joint_var]
+
+
+@jdc.jit
+def _compute_pose_error(
+    robot: pk.Robot,
+    joint_cfg: jax.Array,
+    target_link_index: jax.Array,
+    target_wxyz: jax.Array,
+    target_position: jax.Array,
+) -> jax.Array:
+    """Compute position error between actual and target pose.
+
+    Returns:
+        pos_error: Position error (Euclidean distance in meters).
+    """
+    Ts_world_link = robot.forward_kinematics(joint_cfg)
+    actual_pose = jaxlie.SE3(Ts_world_link[target_link_index])
+
+    target_pose = jaxlie.SE3.from_rotation_and_translation(
+        jaxlie.SO3(target_wxyz), target_position
+    )
+
+    pose_error = (actual_pose.inverse() @ target_pose).log()
+    pos_error = jnp.linalg.norm(pose_error[:3])
+
+    return pos_error
 
 
 def main():
@@ -38,13 +119,6 @@ def main():
     # Create interactive controller with initial position.
     ik_target = server.scene.add_transform_controls(
         "/ik_target", scale=0.2, position=(0.61, 0.0, 0.56), wxyz=(0, 0, 1, 0)
-    )
-
-    # Create GUI folder for approach selection and metrics.
-    approach_dropdown = server.gui.add_dropdown(
-        "Joint locking",
-        options=["Masked Jacobian", "Masked Retraction"],
-        initial_value="Masked Jacobian",
     )
 
     # Create GUI folder for joint locking controls.
@@ -97,39 +171,29 @@ def main():
         # Build joint mask from checkboxes (1.0 = optimize, 0.0 = lock).
         joint_mask = np.array([float(cb.value) for cb in joint_checkboxes])
 
-        # Prepare common arguments.
+        # Prepare arguments.
         target_link_idx_jax = jnp.array(target_link_index, dtype=jnp.int32)
         target_wxyz_jax = jnp.array(ik_target.wxyz)
         target_position_jax = jnp.array(ik_target.position)
         joint_mask_jax = jnp.array(joint_mask)
         prev_cfg_jax = jnp.array(prev_cfg)
 
-        # Solve IK with selected approach.
+        # Solve IK.
         start_time = time.time()
-        if approach_dropdown.value == "Masked Jacobian":
-            solution = _solve_ik_masked(
-                robot=robot,
-                target_link_index=target_link_idx_jax,
-                target_wxyz=target_wxyz_jax,
-                target_position=target_position_jax,
-                joint_mask=joint_mask_jax,
-                prev_cfg=prev_cfg_jax,
-            )
-        else:
-            solution = _solve_ik_retract_masked(
-                robot=robot,
-                target_link_index=target_link_idx_jax,
-                target_wxyz=target_wxyz_jax,
-                target_position=target_position_jax,
-                joint_mask=joint_mask_jax,
-                prev_cfg=prev_cfg_jax,
-            )
+        solution = _solve_ik(
+            robot=robot,
+            target_link_index=target_link_idx_jax,
+            target_wxyz=target_wxyz_jax,
+            target_position=target_position_jax,
+            joint_mask=joint_mask_jax,
+            prev_cfg=prev_cfg_jax,
+        )
 
         # Update timing.
         elapsed_time = time.time() - start_time
         timing_handle.value = 0.99 * timing_handle.value + 0.01 * (elapsed_time * 1000)
 
-        # Compute accuracy (position and orientation error).
+        # Compute accuracy.
         pos_err = _compute_pose_error(
             robot=robot,
             joint_cfg=solution,
@@ -137,7 +201,6 @@ def main():
             target_wxyz=target_wxyz_jax,
             target_position=target_position_jax,
         )
-        # Update metrics (EMA smoothing, convert to mm and degrees).
         pos_error_handle.value = (
             0.99 * pos_error_handle.value + 0.01 * float(pos_err) * 1000
         )
@@ -154,170 +217,6 @@ def main():
 
         # Update visualizer.
         urdf_vis.update_cfg(solution_np)
-
-
-@jdc.jit
-def _compute_pose_error(
-    robot: pk.Robot,
-    joint_cfg: jax.Array,
-    target_link_index: jax.Array,
-    target_wxyz: jax.Array,
-    target_position: jax.Array,
-) -> jax.Array:
-    """Compute position and orientation error between actual and target pose.
-
-    Returns:
-        pos_error: Position error (Euclidean distance in meters).
-    """
-    # Compute actual end-effector pose.
-    Ts_world_link = robot.forward_kinematics(joint_cfg)
-    actual_pose = jaxlie.SE3(Ts_world_link[target_link_index])
-
-    # Compute target pose.
-    target_pose = jaxlie.SE3.from_rotation_and_translation(
-        jaxlie.SO3(target_wxyz), target_position
-    )
-
-    # Compute pose error in tangent space.
-    pose_error = (actual_pose.inverse() @ target_pose).log()
-
-    # Position error (first 3 components of SE3 tangent).
-    pos_error = jnp.linalg.norm(pose_error[:3])
-
-    return pos_error
-
-
-@jdc.jit
-def _solve_ik_masked(
-    robot: pk.Robot,
-    target_link_index: jax.Array,
-    target_wxyz: jax.Array,
-    target_position: jax.Array,
-    joint_mask: jax.Array,
-    prev_cfg: jax.Array,
-) -> jax.Array:
-    """Solve IK with masked (locked) joints.
-
-    Args:
-        robot: Robot model.
-        target_link_index: Index of the target link.
-        target_wxyz: Target orientation quaternion (w, x, y, z).
-        target_position: Target position (x, y, z).
-        joint_mask: Array of shape (n_actuated,). 1.0 = optimize, 0.0 = lock.
-        prev_cfg: Previous joint configuration (used as initial guess).
-
-    Returns:
-        Optimized joint configuration.
-    """
-    joint_var = robot.joint_var_cls(0)
-
-    target_pose = jaxlie.SE3.from_rotation_and_translation(
-        jaxlie.SO3(target_wxyz), target_position
-    )
-
-    costs = [
-        # Use the masked pose cost - locked joints get zero Jacobian.
-        pk.costs.pose_cost_analytic_jac_masked(
-            robot,
-            joint_var,
-            target_pose,
-            target_link_index,
-            pos_weight=50.0,
-            ori_weight=10.0,
-            joint_mask=joint_mask,
-        ),
-        # Joint limits (still applied to all joints).
-        pk.costs.limit_constraint(
-            robot,
-            joint_var,
-        ),
-    ]
-
-    sol = (
-        jaxls.LeastSquaresProblem(costs=costs, variables=[joint_var])
-        .analyze()
-        .solve(
-            verbose=False,
-            linear_solver="dense_cholesky",
-            trust_region=jaxls.TrustRegionConfig(lambda_initial=1.0),
-            initial_vals=jaxls.VarValues.make([joint_var.with_value(prev_cfg)]),
-        )
-    )
-    return sol[joint_var]
-
-
-@jdc.jit
-def _solve_ik_retract_masked(
-    robot: pk.Robot,
-    target_link_index: jax.Array,
-    target_wxyz: jax.Array,
-    target_position: jax.Array,
-    joint_mask: jax.Array,
-    prev_cfg: jax.Array,
-) -> jax.Array:
-    """Solve IK with retract-based joint locking.
-
-    Instead of masking the Jacobian, this approach uses a custom retract_fn
-    that filters delta updates for locked joints.
-
-    Args:
-        robot: Robot model.
-        target_link_index: Index of the target link.
-        target_wxyz: Target orientation quaternion (w, x, y, z).
-        target_position: Target position (x, y, z).
-        joint_mask: Array of shape (n_actuated,). 1.0 = optimize, 0.0 = lock.
-        prev_cfg: Previous joint configuration (used as initial guess).
-
-    Returns:
-        Optimized joint configuration.
-    """
-
-    # Custom retract function that filters delta updates for locked joints.
-    def retract_fn(vals: jax.Array, delta: jax.Array) -> jax.Array:
-        return vals + delta * joint_mask
-
-    # Create a custom variable class with the masked retract function.
-    class MaskedJointVar(
-        jaxls.Var[jax.Array],
-        default_factory=robot.joint_var_cls(0).default_factory,
-        tangent_dim=robot.joints.num_actuated_joints,
-        retract_fn=retract_fn,
-    ): ...
-
-    joint_var = MaskedJointVar(0)
-
-    target_pose = jaxlie.SE3.from_rotation_and_translation(
-        jaxlie.SO3(target_wxyz), target_position
-    )
-
-    costs = [
-        # Use standard pose cost (not masked) - retract handles locking.
-        pk.costs.pose_cost_analytic_jac(
-            robot,
-            joint_var,
-            target_pose,
-            target_link_index,
-            pos_weight=50.0,
-            ori_weight=10.0,
-        ),
-        # Joint limits (still applied to all joints).
-        pk.costs.limit_constraint(
-            robot,
-            joint_var,
-        ),
-    ]
-
-    sol = (
-        jaxls.LeastSquaresProblem(costs=costs, variables=[joint_var])
-        .analyze()
-        .solve(
-            verbose=False,
-            linear_solver="dense_cholesky",
-            trust_region=jaxls.TrustRegionConfig(lambda_initial=1.0),
-            initial_vals=jaxls.VarValues.make([joint_var.with_value(prev_cfg)]),
-        )
-    )
-    return sol[joint_var]
 
 
 if __name__ == "__main__":

--- a/src/pyroki/_residuals/_pose_residual_analytic_jac.py
+++ b/src/pyroki/_residuals/_pose_residual_analytic_jac.py
@@ -81,6 +81,7 @@ def pose_cost_analytic_jac(
     target_link_index: jax.Array,
     pos_weight: jax.Array | float,
     ori_weight: jax.Array | float,
+    joint_mask: jax.Array | float = 1.0,
 ) -> jaxls.Cost:
     """Create a pose cost with analytic Jacobian computation.
 
@@ -93,6 +94,9 @@ def pose_cost_analytic_jac(
         target_link_index: Index of target link (int32).
         pos_weight: Weight for position error.
         ori_weight: Weight for orientation error.
+        joint_mask: Optional array of shape (n_actuated_joints,) with values in [0, 1].
+            1.0 = joint is optimized, 0.0 = joint is locked (zero Jacobian).
+            Defaults to 1.0 (all joints optimized).
 
     Returns:
         Cost object for pose matching.
@@ -144,6 +148,7 @@ def pose_cost_analytic_jac(
         pos_weight,
         ori_weight,
         joints_applied_to_target,
+        joint_mask,
     )
 
 
@@ -159,189 +164,9 @@ def _pose_cost_jac(
     pos_weight: jax.Array | float,
     ori_weight: jax.Array | float,
     joints_applied_to_target: jax.Array,
+    joint_mask: jax.Array | float,
 ) -> jax.Array:
     """Jacobian for pose cost with analytic computation."""
-    del vals, joint_var, target_pose  # Unused!
-    Ts_world_joint, Ts_world_link, pose_error = jac_cache
-
-    T_world_ee = jaxlie.SE3(Ts_world_link[target_link_index])
-    Ts_world_joint = jaxlie.SE3(Ts_world_joint)
-
-    R_ee_world = T_world_ee.rotation().inverse()
-
-    # Get joint twists; these are scaled for mimic joints.
-    joint_twists = robot.joints.twists * robot.joints.mimic_multiplier[..., None]
-
-    # Get angular velocity components (omega).
-    omega_local = joint_twists[:, 3:]
-    omega_wrt_world = Ts_world_joint.rotation() @ omega_local
-    omega_wrt_ee = R_ee_world @ omega_wrt_world
-
-    # Get linear velocity components (v).
-    vel_local = joint_twists[:, :3]
-    vel_wrt_world = Ts_world_joint.rotation() @ vel_local
-
-    # Compute the linear velocity component (v = ω × r + v_joint).
-    vel_wrt_world = (
-        jnp.cross(
-            omega_wrt_world,
-            T_world_ee.translation() - Ts_world_joint.translation(),
-        )
-        + vel_wrt_world
-    )
-    vel_wrt_ee = R_ee_world @ vel_wrt_world
-
-    # Combine into spatial Jacobian.
-    jac = jnp.where(
-        joints_applied_to_target[:, None] != -1,
-        jnp.concatenate(
-            [
-                vel_wrt_ee,
-                omega_wrt_ee,
-            ],
-            axis=1,
-        ),
-        0.0,
-    ).T
-    jac = pose_error.jlog() @ jac
-
-    # Jacobian of all joints => Jacobian of actuated joints.
-    #
-    # Because of mimic joints, the Jacobian terms from multiple joints can be
-    # applied to a single actuated joint. This is summed!
-    jac = (
-        jnp.zeros((6, robot.joints.num_actuated_joints))
-        .at[:, joints_applied_to_target]
-        .add((joints_applied_to_target[None, :] != -1) * jac)
-    )
-
-    # Apply weights
-    weights = jnp.array([pos_weight] * 3 + [ori_weight] * 3)
-    return jac * weights[:, None]
-
-
-@jaxls.Cost.factory(jac_custom_with_cache_fn=_pose_cost_jac)
-def _pose_cost_analytical_jac(
-    vals: jaxls.VarValues,
-    robot: Robot,
-    joint_var: jaxls.Var[jax.Array],
-    target_pose: jaxlie.SE3,
-    target_link_index: jax.Array,
-    pos_weight: jax.Array | float,
-    ori_weight: jax.Array | float,
-    joints_applied_to_target: jax.Array,
-) -> tuple[jax.Array, _PoseCostJacCache]:
-    """Computes the residual for matching link poses to target poses."""
-    del joints_applied_to_target
-    assert target_link_index.dtype == jnp.int32
-    joint_cfg = vals[joint_var]
-
-    Ts_world_joint = robot._forward_kinematics_joints(joint_cfg)
-    Ts_world_link = robot._link_poses_from_joint_poses(Ts_world_joint)
-
-    T_world_ee = jaxlie.SE3(Ts_world_link[target_link_index, :])
-    pose_error = target_pose.inverse() @ T_world_ee
-    return (
-        pose_error.log() * jnp.array([pos_weight] * 3 + [ori_weight] * 3),
-        # Second argument is cache parameter, which is passed to the custom Jacobian function.
-        (Ts_world_joint, Ts_world_link, pose_error),
-    )
-
-
-def pose_cost_analytic_jac_masked(
-    robot: Robot,
-    joint_var: jaxls.Var[jax.Array],
-    target_pose: jaxlie.SE3,
-    target_link_index: jax.Array,
-    pos_weight: jax.Array | float,
-    ori_weight: jax.Array | float,
-    joint_mask: jax.Array,
-) -> jaxls.Cost:
-    """Create a pose cost with analytic Jacobian and joint masking.
-
-    Like pose_cost_analytic_jac, but allows locking specific joints by zeroing
-    their Jacobian contributions. Joints with mask=0 will have zero Jacobian
-    columns, so the optimizer will not update them.
-
-    This is useful for reducing optimization complexity by excluding certain
-    joints from the optimization while keeping the same JIT-compiled function.
-
-    Args:
-        robot: Robot model.
-        joint_var: Joint configuration variable.
-        target_pose: Target SE3 pose.
-        target_link_index: Index of target link (int32).
-        pos_weight: Weight for position error.
-        ori_weight: Weight for orientation error.
-        joint_mask: Array of shape (n_actuated_joints,) with values in [0, 1].
-            1.0 = joint is optimized, 0.0 = joint is locked (zero Jacobian).
-
-    Returns:
-        Cost object for pose matching with masked joints.
-    """
-    # We only check shape lengths because there might be (1,) axes for
-    # broadcasting reasons.
-    assert (
-        len(target_link_index.shape)
-        == len(jnp.asarray(joint_var.id).shape)
-        == len(robot.joints.twists.shape[:-2])
-    ), "Batch axes of inputs should match"
-
-    # Broadcast the inputs for _get_actuated_joints_applied_to_target().
-    batch_axes = jnp.broadcast_shapes(
-        target_pose.get_batch_axes(),
-        jnp.asarray(joint_var.id).shape,
-        target_pose.get_batch_axes(),
-        target_link_index.shape,
-    )
-    broadcast_batch_axes = partial(
-        jax.tree.map,
-        lambda x: jnp.broadcast_to(x, batch_axes + x.shape[len(batch_axes) :]),
-    )
-    get_actuated_joints = _get_actuated_joints_applied_to_target
-    for _ in range(len(batch_axes)):
-        get_actuated_joints = jax.vmap(get_actuated_joints)
-
-    # Compute applied joints.
-    robot = broadcast_batch_axes(robot)
-    link_parent_joint_indices = jnp.array(
-        robot.links.parent_joint_indices, dtype=jnp.int32
-    )
-    base_link_mask = link_parent_joint_indices == -1
-    parent_joint_indices = jnp.where(base_link_mask, 0, link_parent_joint_indices)
-    target_joint_idx = parent_joint_indices[
-        tuple(jnp.arange(d) for d in parent_joint_indices.shape[:-1])
-        + (target_link_index,)
-    ]
-    joints_applied_to_target = get_actuated_joints(
-        broadcast_batch_axes(robot), broadcast_batch_axes(target_joint_idx)
-    )
-
-    return _pose_cost_analytical_jac_masked(
-        robot,
-        joint_var,
-        target_pose,
-        target_link_index,
-        pos_weight,
-        ori_weight,
-        joints_applied_to_target,
-        joint_mask,
-    )
-
-
-def _pose_cost_jac_masked(
-    vals: jaxls.VarValues,
-    jac_cache: _PoseCostJacCache,
-    robot: Robot,
-    joint_var: jaxls.Var[jax.Array],
-    target_pose: jaxlie.SE3,
-    target_link_index: jax.Array,
-    pos_weight: jax.Array | float,
-    ori_weight: jax.Array | float,
-    joints_applied_to_target: jax.Array,
-    joint_mask: jax.Array,
-) -> jax.Array:
-    """Jacobian for pose cost with analytic computation and joint masking."""
     del vals, joint_var, target_pose  # Unused!
     Ts_world_joint, Ts_world_link, pose_error = jac_cache
 
@@ -404,8 +229,8 @@ def _pose_cost_jac_masked(
     return jac * weights[:, None]
 
 
-@jaxls.Cost.factory(jac_custom_with_cache_fn=_pose_cost_jac_masked)
-def _pose_cost_analytical_jac_masked(
+@jaxls.Cost.factory(jac_custom_with_cache_fn=_pose_cost_jac)
+def _pose_cost_analytical_jac(
     vals: jaxls.VarValues,
     robot: Robot,
     joint_var: jaxls.Var[jax.Array],
@@ -414,9 +239,9 @@ def _pose_cost_analytical_jac_masked(
     pos_weight: jax.Array | float,
     ori_weight: jax.Array | float,
     joints_applied_to_target: jax.Array,
-    joint_mask: jax.Array,
+    joint_mask: jax.Array | float,
 ) -> tuple[jax.Array, _PoseCostJacCache]:
-    """Computes the residual for matching link poses to target poses (masked version)."""
+    """Computes the residual for matching link poses to target poses."""
     del joints_applied_to_target, joint_mask  # Only used in Jacobian
     assert target_link_index.dtype == jnp.int32
     joint_cfg = vals[joint_var]

--- a/src/pyroki/costs.py
+++ b/src/pyroki/costs.py
@@ -25,7 +25,6 @@ from ._residuals import (
 )
 from ._residuals._pose_residual_analytic_jac import (
     pose_cost_analytic_jac as pose_cost_analytic_jac,
-    pose_cost_analytic_jac_masked as pose_cost_analytic_jac_masked,
 )
 from ._residuals._pose_residual_numerical_jac import (
     pose_cost_numerical_jac as pose_cost_numerical_jac,


### PR DESCRIPTION
Modify the analytical pose cost to support locking joints, by masking Jacobians for contributions from locked joints. This doesn't avoid the full gradient calculation, but it seems to be faster since it doesn't mess with the termination conditions. If you were to instead mask the variable updates (similar to the mobile IK example), then the optimizer thinks that there is a perpetual error, causing it to run more iterations.

Could be generally useful (#48)?

https://github.com/user-attachments/assets/552a5980-bf74-40af-b9f3-c60a43a791d0

